### PR TITLE
貸出可否チェック機能追加

### DIFF
--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import jp.co.metateam.library.model.RentalManage;
@@ -14,6 +15,7 @@ public interface RentalManageRepository extends JpaRepository<RentalManage, Long
 
 	Optional<RentalManage> findById(Long id);
 
-    List<RentalManage> findAllByStatusIn(List<Integer> statuses);
+    @Query("select r from RentalManage r where r.stock.id = ?1 and r.status in (0,1)")
+    List<RentalManage> findByStockId(String StockId);
 
 }

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -13,4 +13,7 @@ public interface RentalManageRepository extends JpaRepository<RentalManage, Long
     List<RentalManage> findAll();
 
 	Optional<RentalManage> findById(Long id);
+
+    List<RentalManage> findAllByStatusIn(List<Integer> statuses);
+
 }

--- a/src/main/java/jp/co/metateam/library/service/RentalManageService.java
+++ b/src/main/java/jp/co/metateam/library/service/RentalManageService.java
@@ -2,10 +2,14 @@ package jp.co.metateam.library.service;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Arrays;
+import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 
 import jp.co.metateam.library.model.Account;
 import jp.co.metateam.library.model.BookMst;
@@ -17,8 +21,13 @@ import jp.co.metateam.library.repository.RentalManageRepository;
 import jp.co.metateam.library.repository.StockRepository;
 import jp.co.metateam.library.values.RentalStatus;
 
+
+import jp.co.metateam.library.service.StockService;
+
+
 @Service
 public class RentalManageService {
+
 
     private final AccountRepository accountRepository;
     private final RentalManageRepository rentalManageRepository;
@@ -46,6 +55,12 @@ public class RentalManageService {
     public RentalManage findById(Long id) {
         return this.rentalManageRepository.findById(id).orElse(null);
     }
+
+    @Transactional
+    public List<RentalManage> findAllByStatusIn(List<Integer> statuses) {
+        return rentalManageRepository.findAllByStatusIn(statuses);
+    }
+
 
     @Transactional 
     public void save(RentalManageDto rentalManageDto) throws Exception {
@@ -126,6 +141,36 @@ public class RentalManageService {
             throw e;
         }
     } 
+
+
+
+
+
+
+
+    public void available(Long id, RentalManageDto rentalManageDto, BindingResult result) throws Exception {
+        try {
+
+           
+        } catch (Exception e) {
+            // Handle the exception
+            throw e;
+        }
+    }
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
  
 }
 

--- a/src/main/java/jp/co/metateam/library/service/RentalManageService.java
+++ b/src/main/java/jp/co/metateam/library/service/RentalManageService.java
@@ -57,8 +57,8 @@ public class RentalManageService {
     }
 
     @Transactional
-    public List<RentalManage> findAllByStatusIn(List<Integer> statuses) {
-        return rentalManageRepository.findAllByStatusIn(statuses);
+    public List<RentalManage> findByStockId(String StockId) {
+        return this.rentalManageRepository.findByStockId(StockId);
     }
 
 
@@ -141,37 +141,6 @@ public class RentalManageService {
             throw e;
         }
     } 
-
-
-
-
-
-
-
-    public void available(Long id, RentalManageDto rentalManageDto, BindingResult result) throws Exception {
-        try {
-
-           
-        } catch (Exception e) {
-            // Handle the exception
-            throw e;
-        }
-    }
-    
-
-
-
-
-
-
-
-
-
-
-
-
-
- 
 }
 
 

--- a/target/classes/static/js/rental/add.js
+++ b/target/classes/static/js/rental/add.js
@@ -1,0 +1,36 @@
+function dateFormat(today, format) {
+    format = format.replace("YYYY", today.getFullYear());
+    format = format.replace("MM", ("0"+(today.getMonth() + 1)).slice(-2));
+    format = format.replace("DD", ("0"+ today.getDate()).slice(-2));
+    return format;
+}
+
+function setExpectedRentalOn() {
+    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    $("#expectedRentalOn").attr("min", date);
+}
+
+function setExpectedReturnOn() {
+    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    $("#expectedReturnOn").attr("min", date);
+}
+
+
+$(function() {
+    // 各日付の最小値を指定（登録日当日の日付）
+    // setExpectedRentalOn();
+    // setExpectedReturnOn();
+
+    // 貸出予定日が変更された場合、返却予定日の最小値を変更
+    // 貸出予定日 =< 返却予定日 となるようにする
+    $("#expectedRentalOn").on("change", function(){
+        let value = $(this).val();
+        $("#expectedReturnOn").val(null);
+        if (value === null) {
+            // setExpectedRentalOn();
+            // setExpectedReturnOn();
+        } else {
+            $("#expectedReturnOn").attr("min", $(this).val());
+        }
+    });
+})

--- a/target/classes/static/js/rental/edit.js
+++ b/target/classes/static/js/rental/edit.js
@@ -1,0 +1,36 @@
+function dateFormat(today, format) {
+    format = format.replace("YYYY", today.getFullYear());
+    format = format.replace("MM", ("0"+(today.getMonth() + 1)).slice(-2));
+    format = format.replace("DD", ("0"+ today.getDate()).slice(-2));
+    return format;
+}
+
+function setExpectedRentalOn() {
+    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    $("#expectedRentalOn").attr("min", date);
+}
+
+function setExpectedReturnOn() {
+    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    $("#expectedReturnOn").attr("min", date);
+}
+
+
+$(function() {
+    // 各日付の最小値を指定（登録日当日の日付）
+    // setExpectedRentalOn();
+    // setExpectedReturnOn();
+
+    // 貸出予定日が変更された場合、返却予定日の最小値を変更
+    // 貸出予定日 =< 返却予定日 となるようにする
+    $("#expectedRentalOn").on("change", function(){
+        let value = $(this).val();
+        $("#expectedReturnOn").val(null);
+        if (value === null) {
+            // setExpectedRentalOn();
+            // setExpectedReturnOn();
+        } else {
+            $("#expectedReturnOn").attr("min", $(this).val());
+        }
+    });
+})


### PR DESCRIPTION
貸出登録画面、貸出編集画面に貸出可否チェックを追加しました。

概要
RentalManegeController内の 
・@PostMapping("/rental/add")に貸出可否チェック
・@GetMapping("/rental/{id}/edit")に貸出可否チェック
　→@PostMapping("/rental/add")のほうと違う部分は259行目に貸出管理番号が一致しているDBのデータについては処理をスキップするようにしています。
　
貸出可否チェック内で使用するfindAllByStatusIn(List<Integer> statuses);をRentalManageRepositoryの17行目に定義し、メソッドをRentalManageServiceの59～62行目に定義しました。