### PR TITLE
修正版＿5/21＿貸出可否チェック機能追加

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -16,6 +16,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import jakarta.validation.Valid;
 import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.model.CalenderDto;
 import jp.co.metateam.library.model.Stock;
 import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.service.BookMstService;
@@ -41,7 +42,7 @@ public class StockController {
 
     @GetMapping("/stock/index")
     public String index(Model model) {
-        List <Stock> stockList = this.stockService.findAll();
+        List<Stock> stockList = this.stockService.findAll();
 
         model.addAttribute("stockList", stockList);
 
@@ -113,7 +114,8 @@ public class StockController {
     }
 
     @PostMapping("/stock/{id}/edit")
-    public String update(@PathVariable("id") String id, @Valid @ModelAttribute StockDto stockDto, BindingResult result, RedirectAttributes ra) {
+    public String update(@PathVariable("id") String id, @Valid @ModelAttribute StockDto stockDto, BindingResult result,
+            RedirectAttributes ra) {
         try {
             if (result.hasErrors()) {
                 throw new Exception("Validation error.");
@@ -133,7 +135,8 @@ public class StockController {
     }
 
     @GetMapping("/stock/calendar")
-    public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month, Model model) {
+    public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month,
+            Model model) {
 
         LocalDate today = year == null || month == null ? LocalDate.now() : LocalDate.of(year, month, 1);
         Integer targetYear = year == null ? today.getYear() : year;
@@ -143,14 +146,13 @@ public class StockController {
         Integer daysInMonth = startDate.lengthOfMonth();
 
         List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth);
-        List<String> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
+        List<List<CalenderDto>> stocksLists = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
 
         model.addAttribute("targetYear", targetYear);
         model.addAttribute("targetMonth", targetMonth);
         model.addAttribute("daysOfWeek", daysOfWeek);
         model.addAttribute("daysInMonth", daysInMonth);
-
-        model.addAttribute("stocks", stocks);
+        model.addAttribute("stocksLists", stocksLists);
 
         return "stock/calendar";
     }

--- a/src/main/java/jp/co/metateam/library/model/CalenderDto.java
+++ b/src/main/java/jp/co/metateam/library/model/CalenderDto.java
@@ -1,0 +1,22 @@
+package jp.co.metateam.library.model;
+
+import java.util.Date;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CalenderDto {
+
+    private String title;
+
+    private Long stockNum;
+
+    private Date expectedRentalOn;
+
+    private String stockId;
+
+    private Object dayStockNum;
+
+}

--- a/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
@@ -1,9 +1,16 @@
 package jp.co.metateam.library.model;
 
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -19,21 +26,21 @@ public class RentalManageDto {
 
     private Long id;
 
-    @NotEmpty(message="在庫管理番号は必須です")
+    @NotEmpty(message = "在庫管理番号は必須です")
     private String stockId;
 
-    @NotEmpty(message="社員番号は必須です")
+    @NotEmpty(message = "社員番号は必須です")
     private String employeeId;
 
-    @NotNull(message="貸出ステータスは必須です")
+    @NotNull(message = "貸出ステータスは必須です")
     private Integer status;
 
-    @DateTimeFormat(pattern="yyyy-MM-dd")
-    @NotNull(message="貸出予定日は必須です")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @NotNull(message = "貸出予定日は必須です")
     private Date expectedRentalOn;
 
-    @DateTimeFormat(pattern="yyyy-MM-dd")
-    @NotNull(message="返却予定日は必須です")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @NotNull(message = "返却予定日は必須です")
     private Date expectedReturnOn;
 
     private Timestamp rentaledAt;
@@ -45,5 +52,71 @@ public class RentalManageDto {
     private Stock stock;
 
     private Account account;
+
+    // 貸出登録可否チェック
+    public boolean validRentalDateAdd(List<RentalManage> rentalManageList) {
+        for (RentalManage rentalManage : rentalManageList) {
+            Date listRentalRentalOn = rentalManage.getExpectedRentalOn();
+            Date listRentalReturnOn = rentalManage.getExpectedReturnOn();
+
+            if (!((expectedReturnOn.before(listRentalRentalOn))
+                    || (listRentalReturnOn.before(expectedRentalOn)))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // 貸出編集可否チェック
+    public boolean validRentalDateEdit(List<RentalManage> rentalManageList) {
+        for (RentalManage rentalManage : rentalManageList) {
+            if (!id.equals(rentalManage.getId())) {
+                Date listRentalRentalOn = rentalManage.getExpectedRentalOn();
+                Date listRentalReturnOn = rentalManage.getExpectedReturnOn();
+
+                if (!((expectedReturnOn.before(listRentalRentalOn))
+                        || (listRentalReturnOn.before(expectedRentalOn)))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    // 貸出ステータスチェック
+    public String validStatus(RentalManage valRentalManage) {
+
+        int status = valRentalManage.getStatus();
+        int newStatus = this.getStatus();
+        LocalDateTime ldt = LocalDateTime.now();
+        Date expectedRentalOn = this.getExpectedRentalOn();
+        Date expectedReturnOn = this.getExpectedReturnOn();
+
+        LocalDateTime expectedRentalOnLdt = Instant.ofEpochMilli(expectedRentalOn.getTime())
+                .atZone(ZoneId.systemDefault()).toLocalDateTime();
+        LocalDateTime expectedReturnOnLdt = Instant.ofEpochMilli(expectedReturnOn.getTime())
+                .atZone(ZoneId.systemDefault()).toLocalDateTime();
+
+        if (newStatus == 1 && ldt.isBefore(expectedRentalOnLdt)) {
+            return "貸出予定日が未来のためこのステータスは選択できません";
+
+        } else if (newStatus == 2 && ldt.isBefore(expectedReturnOnLdt)) {
+            return "返却予定日が未来のためこのステータスは選択できません";
+
+        } else if (status == 0 && newStatus == 2) {
+            return "このステータスは選択できません";
+
+        } else if (status == 1 && (newStatus == 0 || newStatus == 3)) {
+            return "このステータスは選択できません";
+
+        } else if (status == 2 && (newStatus == 0 || newStatus == 1 || newStatus == 3)) {
+            return "返却済みからステータスの変更はできません";
+
+        } else if (status == 3 && (newStatus == 0 || newStatus == 1 || newStatus == 2)) {
+            return "キャンセルからステータスの変更はできません";
+
+        }
+        return "";
+    }
 
 }

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -13,26 +13,29 @@ import java.util.Date;
 
 @Repository
 public interface RentalManageRepository extends JpaRepository<RentalManage, Long> {
-    List<RentalManage> findAll();
+        List<RentalManage> findAll();
 
-    Optional<RentalManage> findById(Long id);
+        Optional<RentalManage> findById(Long id);
 
-    @Query("select r from RentalManage r where r.stock.id = ?1 and r.status in (0,1)")
-    List<RentalManage> findByStockId(String StockId);
+        @Query("select r from RentalManage r where r.stock.id = ?1 and r.status in (0,1)")
+        List<RentalManage> findByStockId(String StockId);
 
-    // タイトルに紐づく貸出予定日＝＜day ＆＆ day＝＜返却予定日の数をカウント
-    @Query(value = "SELECT COUNT(*) AS count " +
-            "FROM rental_manage rm " +
-            "JOIN stocks s ON rm.stock_id = s.id " +
-            "JOIN book_mst bm ON s.book_id = bm.id " +
-            "WHERE rm.expected_rental_on <= :day AND :day <= rm.expected_return_on AND bm.title = :title", nativeQuery = true)
-    Long findByUnAvailableCount(@Param("day") Date day, @Param("title") String title);
+        // タイトルに紐づく貸出予定日＝＜day ＆＆ day＝＜返却予定日の数をカウント
+        @Query(value = "SELECT COUNT(*) AS count " +
+                        "FROM rental_manage rm " +
+                        "JOIN stocks s ON rm.stock_id = s.id " +
+                        "JOIN book_mst bm ON s.book_id = bm.id " +
+                        "WHERE rm.expected_rental_on <= :day AND :day <= rm.expected_return_on AND bm.title = :title", nativeQuery = true)
+        Long findByUnAvailableCount(@Param("day") Date day, @Param("title") String title);
 
-    @Query(value = "SELECT s.id " +
-            "FROM stocks s " +
-            "LEFT JOIN rental_manage rm ON s.id = rm.stock_id " +
-            "JOIN book_mst bm ON s.book_id = bm.id " +
-            "WHERE rm.stock_id IS NULL OR rm.expected_rental_on > :day OR :day > rm.expected_return_on AND bm.title = :title", nativeQuery = true)
-    List<String> findByAvailableStockId(@Param("day") Date day, @Param("title") String title);
+        @Query(value = "SELECT st.id " +
+                        "FROM stocks st " +
+                        "JOIN book_mst bm ON st.book_id = bm.id " +
+                        "LEFT JOIN rental_manage rm ON st.id = rm.stock_id " +
+                        "WHERE (rm.expected_rental_on > :day OR rm.expected_return_on < :day OR rm.stock_id IS NULL) "
+                        +
+                        "AND bm.title = :title " +
+                        "AND st.status = '0' ", nativeQuery = true)
+        List<String> findByAvailableStockId(@Param("day") Date day, @Param("title") String title);
 
 }

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -5,17 +5,34 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import jp.co.metateam.library.model.RentalManage;
+import java.util.Date;
 
 @Repository
 public interface RentalManageRepository extends JpaRepository<RentalManage, Long> {
     List<RentalManage> findAll();
 
-	Optional<RentalManage> findById(Long id);
+    Optional<RentalManage> findById(Long id);
 
     @Query("select r from RentalManage r where r.stock.id = ?1 and r.status in (0,1)")
     List<RentalManage> findByStockId(String StockId);
+
+    // タイトルに紐づく貸出予定日＝＜day ＆＆ day＝＜返却予定日の数をカウント
+    @Query(value = "SELECT COUNT(*) AS count " +
+            "FROM rental_manage rm " +
+            "JOIN stocks s ON rm.stock_id = s.id " +
+            "JOIN book_mst bm ON s.book_id = bm.id " +
+            "WHERE rm.expected_rental_on <= :day AND :day <= rm.expected_return_on AND bm.title = :title", nativeQuery = true)
+    Long findByUnAvailableCount(@Param("day") Date day, @Param("title") String title);
+
+    @Query(value = "SELECT s.id " +
+            "FROM stocks s " +
+            "LEFT JOIN rental_manage rm ON s.id = rm.stock_id " +
+            "JOIN book_mst bm ON s.book_id = bm.id " +
+            "WHERE rm.stock_id IS NULL OR rm.expected_rental_on > :day OR :day > rm.expected_return_on AND bm.title = :title", nativeQuery = true)
+    List<String> findByAvailableStockId(@Param("day") Date day, @Param("title") String title);
 
 }

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -4,20 +4,28 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import jp.co.metateam.library.model.CalenderDto;
 import jp.co.metateam.library.model.Stock;
 
 @Repository
 public interface StockRepository extends JpaRepository<Stock, Long> {
-    
+
     List<Stock> findAll();
 
     List<Stock> findByDeletedAtIsNull();
 
     List<Stock> findByDeletedAtIsNullAndStatus(Integer status);
 
-	Optional<Stock> findById(String id);
-    
-    List<Stock> findByBookMstIdAndStatus(Long book_id,Integer status);
+    Optional<Stock> findById(String id);
+
+    List<Stock> findByBookMstIdAndStatus(Long book_id, Integer status);
+
+    @Query(value = "SELECT bm.title, COUNT(st.id) AS availableStockCount " +
+            "FROM book_mst bm " +
+            "LEFT JOIN stocks st ON bm.id = st.book_id AND st.status = 0 " +
+            "GROUP BY bm.title", nativeQuery = true)
+    List<Object[]> findAllAvailableStockCounts();
 }

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import jp.co.metateam.library.model.CalenderDto;

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 import java.util.Random;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -156,8 +157,10 @@ public class StockService {
                 stockCalenderDto.setExpectedRentalOn(day);
 
                 Long unAvailableCount = findByUnAvailableCount(day, title);
-                List<String> stockIdList = findByAvailableStockId(day, title);
-                stockCalenderDto.setStockId(stockIdList.get(0));
+                List<String> AvailStockIdList = findByAvailableStockId(day, title);
+                if (!AvailStockIdList.isEmpty()) {
+                    stockCalenderDto.setStockId(AvailStockIdList.get(0));
+                }
 
                 Long dayStockNum = stockNum - unAvailableCount;
                 if (dayStockNum == 0) {

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -3,6 +3,7 @@ package jp.co.metateam.library.service;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
@@ -13,20 +14,26 @@ import org.springframework.transaction.annotation.Transactional;
 
 import jp.co.metateam.library.constants.Constants;
 import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.model.CalenderDto;
 import jp.co.metateam.library.model.Stock;
 import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.repository.BookMstRepository;
 import jp.co.metateam.library.repository.StockRepository;
+import jp.co.metateam.library.repository.RentalManageRepository;
+import java.util.Date;
 
 @Service
 public class StockService {
     private final BookMstRepository bookMstRepository;
     private final StockRepository stockRepository;
+    private final RentalManageRepository rentalManageRepository;
 
     @Autowired
-    public StockService(BookMstRepository bookMstRepository, StockRepository stockRepository){
+    public StockService(BookMstRepository bookMstRepository, StockRepository stockRepository,
+            RentalManageRepository rentalManageRepository) {
         this.bookMstRepository = bookMstRepository;
         this.stockRepository = stockRepository;
+        this.rentalManageRepository = rentalManageRepository;
     }
 
     @Transactional
@@ -35,10 +42,10 @@ public class StockService {
 
         return stocks;
     }
-    
+
     @Transactional
-    public List <Stock> findStockAvailableAll() {
-        List <Stock> stocks = this.stockRepository.findByDeletedAtIsNullAndStatus(Constants.STOCK_AVAILABLE);
+    public List<Stock> findStockAvailableAll() {
+        List<Stock> stocks = this.stockRepository.findByDeletedAtIsNullAndStatus(Constants.STOCK_AVAILABLE);
 
         return stocks;
     }
@@ -48,7 +55,22 @@ public class StockService {
         return this.stockRepository.findById(id).orElse(null);
     }
 
-    @Transactional 
+    @Transactional
+    public List<Object[]> findAllAvailableStockCounts() {
+        return this.stockRepository.findAllAvailableStockCounts();
+    }
+
+    @Transactional
+    public Long findByUnAvailableCount(Date day, String title) {
+        return this.rentalManageRepository.findByUnAvailableCount(day, title);
+    }
+
+    @Transactional
+    public List<String> findByAvailableStockId(Date day, String title) {
+        return this.rentalManageRepository.findByAvailableStockId(day, title);
+    }
+
+    @Transactional
     public void save(StockDto stockDto) throws Exception {
         try {
             Stock stock = new Stock();
@@ -69,7 +91,7 @@ public class StockService {
         }
     }
 
-    @Transactional 
+    @Transactional
     public void update(String id, StockDto stockDto) throws Exception {
         try {
             Stock stock = findById(id);
@@ -93,7 +115,7 @@ public class StockService {
             throw e;
         }
     }
- 
+
     public List<Object> generateDaysOfWeek(int year, int month, LocalDate startDate, int daysInMonth) {
         List<Object> daysOfWeek = new ArrayList<>();
         for (int dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++) {
@@ -105,19 +127,51 @@ public class StockService {
         return daysOfWeek;
     }
 
-    public List<String> generateValues(Integer year, Integer month, Integer daysInMonth) {
-        // FIXME ここで各書籍毎の日々の在庫を生成する処理を実装する
-        // FIXME ランダムに値を返却するサンプルを実装している
-        String[] stockNum = {"1", "2", "3", "4", "×"};
-        Random rnd = new Random();
-        List<String> values = new ArrayList<>();
-        values.add("スッキリわかるJava入門 第4版"); // 対象の書籍名
-        values.add("10"); // 対象書籍の在庫総数
-        
-        for (int i = 1; i <= daysInMonth; i++) {
-            int index = rnd.nextInt(stockNum.length);
-            values.add(stockNum[index]);
+    public List<List<CalenderDto>> generateValues(Integer year, Integer month, Integer daysInMonth) {
+        List<Object[]> titleAndStatus = findAllAvailableStockCounts();
+
+        List<List<CalenderDto>> stockDatasLists = new ArrayList<>();
+
+        for (Object[] data : titleAndStatus) {
+            List<CalenderDto> stockDataList = new ArrayList<>();
+            String title = (String) data[0];
+            Long stockNum = (Long) data[1];
+
+            for (int i = 1; i <= daysInMonth; i++) {
+                CalenderDto stockCalenderDto = new CalenderDto();
+                stockCalenderDto.setTitle(title);
+                stockCalenderDto.setStockNum(stockNum);
+                Calendar calendar = Calendar.getInstance();
+                calendar.set(Calendar.YEAR, year);
+                calendar.set(Calendar.MONTH, month - 1);
+                calendar.set(Calendar.DAY_OF_MONTH, i);
+
+                // 時間を切り捨てる
+                calendar.set(Calendar.HOUR_OF_DAY, 0);
+                calendar.set(Calendar.MINUTE, 0);
+                calendar.set(Calendar.SECOND, 0);
+                calendar.set(Calendar.MILLISECOND, 0);
+
+                Date day = calendar.getTime();
+                stockCalenderDto.setExpectedRentalOn(day);
+
+                Long unAvailableCount = findByUnAvailableCount(day, title);
+                List<String> stockIdList = findByAvailableStockId(day, title);
+                stockCalenderDto.setStockId(stockIdList.get(0));
+
+                Long dayStockNum = stockNum - unAvailableCount;
+                if (dayStockNum == 0) {
+                    String dayStockNoNum = "×";
+                    stockCalenderDto.setDayStockNum(dayStockNoNum);
+                } else {
+                    stockCalenderDto.setDayStockNum(dayStockNum);
+                }
+                stockDataList.add(stockCalenderDto);
+            }
+            stockDatasLists.add(stockDataList);
         }
-        return values;
+
+        return stockDatasLists;
     }
+
 }

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
 <head th:replace="~{common :: meta_header('在庫カレンダー',~{::link},~{::script})}">
     <title th:text="${title}+' | MTLibrary'"></title>
     <link rel="stylesheet" th:href="@{/css/stock/calendar.css}" />
     <script type="text/javascript" th:src="@{/js/stock/add.js}"></script>
 </head>
+
 <body>
     <div class="contents">
         <div th:replace="~{common :: main_sidebar}"></div>
@@ -29,17 +31,35 @@
                             <tr>
                                 <th class="header_book" rowspan="2">書籍名</th>
                                 <th class="header_stock" rowspan="2">在庫数</th>
-                                <th class="header_days" th:colspan="${daysInMonth}" th:text="${targetYear + '年' + targetMonth + '月'}"></th>
+                                <th class="header_days" th:colspan="${daysInMonth}"
+                                    th:text="${targetYear + '年' + targetMonth + '月'}"></th>
                             </tr>
                             <tr class="days">
                                 <th th:each="day : ${daysOfWeek}" th:text="${day}"></th>
                             </tr>
                         </thead>
                         <tbody>
-                            <tr>
-                                <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
-                                <td th:each="stock, stat : ${stocks}" th:text="${stock}"></td>
-                            </tr>
+
+                            <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
+
+
+                            <th:block th:each="stocks : ${stocksLists}">
+                                <tr>
+                                    <td th:text="${stocks[0].title}"></td>
+                                    <td th:text="${stocks[0].stockNum}"></td>
+                                    <td th:each="stock : ${stocks}">
+                                        <span th:if="${stock.dayStockNum != '×'}">
+                                            <a th:href="@{/rental/add(stockId=${stock.stockId}, expectedRentalOn=${#dates.format(stock.expectedRentalOn, 'yyyy-MM-dd')})}"
+                                                th:text="${stock.dayStockNum}"></a>
+                                        </span>
+                                        <span th:if="${stock.dayStockNum == '×'}" th:text="${stock.dayStockNum}"></span>
+                                    </td>
+                                </tr>
+                            </th:block>
+
+
+
+
                         </tbody>
                     </table>
                 </div>

--- a/target/classes/static/js/rental/add.js
+++ b/target/classes/static/js/rental/add.js
@@ -1,29 +1,29 @@
 function dateFormat(today, format) {
     format = format.replace("YYYY", today.getFullYear());
-    format = format.replace("MM", ("0"+(today.getMonth() + 1)).slice(-2));
-    format = format.replace("DD", ("0"+ today.getDate()).slice(-2));
+    format = format.replace("MM", ("0" + (today.getMonth() + 1)).slice(-2));
+    format = format.replace("DD", ("0" + today.getDate()).slice(-2));
     return format;
 }
 
 function setExpectedRentalOn() {
-    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    const date = dateFormat(new Date(), 'YYYY-MM-DD');
     $("#expectedRentalOn").attr("min", date);
 }
 
 function setExpectedReturnOn() {
-    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    const date = dateFormat(new Date(), 'YYYY-MM-DD');
     $("#expectedReturnOn").attr("min", date);
 }
 
 
-$(function() {
+$(function () {
     // 各日付の最小値を指定（登録日当日の日付）
-    // setExpectedRentalOn();
-    // setExpectedReturnOn();
+    setExpectedRentalOn();
+    setExpectedReturnOn();
 
     // 貸出予定日が変更された場合、返却予定日の最小値を変更
     // 貸出予定日 =< 返却予定日 となるようにする
-    $("#expectedRentalOn").on("change", function(){
+    $("#expectedRentalOn").on("change", function () {
         let value = $(this).val();
         $("#expectedReturnOn").val(null);
         if (value === null) {

--- a/target/classes/static/js/rental/edit.js
+++ b/target/classes/static/js/rental/edit.js
@@ -1,29 +1,33 @@
 function dateFormat(today, format) {
     format = format.replace("YYYY", today.getFullYear());
-    format = format.replace("MM", ("0"+(today.getMonth() + 1)).slice(-2));
-    format = format.replace("DD", ("0"+ today.getDate()).slice(-2));
+    format = format.replace("MM", ("0" + (today.getMonth() + 1)).slice(-2));
+    format = format.replace("DD", ("0" + today.getDate()).slice(-2));
     return format;
 }
 
 function setExpectedRentalOn() {
-    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    const date = dateFormat(new Date(), 'YYYY-MM-DD');
     $("#expectedRentalOn").attr("min", date);
 }
 
 function setExpectedReturnOn() {
-    const date = dateFormat(new Date(),'YYYY-MM-DD');
-    $("#expectedReturnOn").attr("min", date);
+    let value = $("#expectedRentalOn").val();
+    if (value == null) {
+        const date = dateFormat(new Date(), 'YYYY-MM-DD');
+        $("#expectedReturnOn").attr("min", date);
+    } else {
+        $("#expectedReturnOn").attr("min", value);
+    }
 }
 
-
-$(function() {
+$(function () {
     // 各日付の最小値を指定（登録日当日の日付）
-    // setExpectedRentalOn();
-    // setExpectedReturnOn();
+    setExpectedRentalOn();
+    setExpectedReturnOn();
 
     // 貸出予定日が変更された場合、返却予定日の最小値を変更
     // 貸出予定日 =< 返却予定日 となるようにする
-    $("#expectedRentalOn").on("change", function(){
+    $("#expectedRentalOn").on("change", function () {
         let value = $(this).val();
         $("#expectedReturnOn").val(null);
         if (value === null) {


### PR DESCRIPTION
概要
RentalManageControllerにかいていたバリデーションチェック（貸出登録画面の可否チェック、貸出編集画面の可否チェックと貸出ステータスチェック）をDtoにメソッドとして定義し、それを呼び出して処理する修正を行いました。
また、Jsのadd.jsとedit.jsで、貸出予定日が今日以降しか選択できないように編集し、edit.jsは返却予定日選択時に貸出予定日に初期データが入っている場合は初期データ以降の日付しか選べない処理を追加しました。